### PR TITLE
Prevent endless loop when server disconnects

### DIFF
--- a/src/main/php/peer/stomp/Connection.class.php
+++ b/src/main/php/peer/stomp/Connection.class.php
@@ -119,10 +119,11 @@ class Connection extends \lang\Object implements Traceable {
     }
 
     $line= null;
-    while (!$line) {
+    $tries= 0;
+    while (!$line && $tries++ < 1000) {
       $line= $this->in->readLine();
     }
-    $this->debug('<<<', 'Have "'.trim($line).'" command.');
+    $this->debug('<<<', 'Have "'.trim($line).'" command, tried', $tries, 'time(s).');
 
     if (0 == strlen($line)) throw new ProtocolException('Expected frame token, got '.\xp::stringOf($line));
 

--- a/src/main/php/peer/stomp/Connection.class.php
+++ b/src/main/php/peer/stomp/Connection.class.php
@@ -118,12 +118,14 @@ class Connection extends \lang\Object implements Traceable {
       return null;
     }
 
-    $line= null;
-    $tries= 0;
-    while (!$line && $tries++ < 1000) {
+    do {
       $line= $this->in->readLine();
-    }
-    $this->debug('<<<', 'Have "'.trim($line).'" command, tried', $tries, 'time(s).');
+      if (null === $line) {
+        $this->_disconnect();
+        throw new ServerDisconnected('Got disconnected from '.$this->socket->toString());
+      }
+    } while ('' === $line);
+    $this->debug('<<<', 'Have "'.trim($line).'" command');
 
     if (0 == strlen($line)) throw new ProtocolException('Expected frame token, got '.\xp::stringOf($line));
 

--- a/src/main/php/peer/stomp/ServerDisconnected.class.php
+++ b/src/main/php/peer/stomp/ServerDisconnected.class.php
@@ -1,0 +1,6 @@
+<?php namespace peer\stomp;
+
+use peer\ProtocolException;
+
+class ServerDisconnected extends ProtocolException {
+}


### PR DESCRIPTION
By limiting the possible number of empty lines before the next frame is
being received. When a server disconnects, there's just nothing more to
read.

Unfortunately, the calls

  $this->socket->isConnected()
  $this->socket->canRead($timeout)

both signal everything's ok, even it's not.